### PR TITLE
 feat(settings): add ability to remove profile picture (#3)

### DIFF
--- a/src/gui/src/UI/Settings/UITabAccount.js
+++ b/src/gui/src/UI/Settings/UITabAccount.js
@@ -180,8 +180,40 @@ export default {
                     $('.profile-image').addClass('profile-image-has-picture');
                     // update profile picture
                     update_profile(window.user.username, {picture: base64data})
-                    // Show remove button if it was hidden
-                    $el_window.find('.remove-profile-picture').parent().show();
+                    // Update window.user.profile for immediate UI updates
+                    if(window.user.profile){
+                        window.user.profile.picture = base64data;
+                    }
+                    // Create or show remove button
+                    let $removeButton = $el_window.find('.remove-profile-picture');
+                    if($removeButton.length === 0){
+                        // Button doesn't exist, create it
+                        const $buttonContainer = $(`<div style="text-align: center; margin-top: 10px;"></div>`);
+                        const $button = $(`<button class="button button-danger remove-profile-picture" style="font-size: 12px;">${i18n('remove_profile_picture')}</button>`);
+                        $buttonContainer.append($button);
+                        $el_window.find('.profile-picture').parent().append($buttonContainer);
+                        // Attach click handler to the new button
+                        $button.on('click', function (e) {
+                            // Remove picture from profile
+                            update_profile(window.user.username, {picture: null});
+                            
+                            // Update UI immediately
+                            $el_window.find('.profile-picture').css('background-image', `url('${window.icons['profile.svg']}')`);
+                            $('.profile-image').css('background-image', `url('${window.icons['profile.svg']}')`);
+                            $('.profile-image').removeClass('profile-image-has-picture');
+                            
+                            // Clear from user object
+                            if(window.user.profile){
+                                window.user.profile.picture = null;
+                            }
+                            
+                            // Hide remove button
+                            $el_window.find('.remove-profile-picture').parent().hide();
+                        });
+                    } else {
+                        // Button exists, just show it
+                        $removeButton.parent().show();
+                    }
                 }
             }
         })

--- a/src/gui/src/UI/Settings/UITabAccount.js
+++ b/src/gui/src/UI/Settings/UITabAccount.js
@@ -37,6 +37,12 @@ export default {
         h += `<div style="overflow: hidden; display: flex; margin-bottom: 20px; flex-direction: column; align-items: center;">`;
             h += `<div class="profile-picture change-profile-picture" style="background-image: url('${html_encode(window.user?.profile?.picture ?? window.icons['profile.svg'])}');">`;
             h += `</div>`;
+            // Remove profile picture button (only show if picture exists)
+            if(window.user?.profile?.picture){
+                h += `<div style="text-align: center; margin-top: 10px;">`;
+                    h += `<button class="button button-danger remove-profile-picture" style="font-size: 12px;">${i18n('remove_profile_picture')}</button>`;
+                h += `</div>`;
+            }
         h += `</div>`;
 
         // change password button
@@ -174,8 +180,29 @@ export default {
                     $('.profile-image').addClass('profile-image-has-picture');
                     // update profile picture
                     update_profile(window.user.username, {picture: base64data})
+                    // Show remove button if it was hidden
+                    $el_window.find('.remove-profile-picture').parent().show();
                 }
             }
         })
+
+        // Remove profile picture button handler
+        $el_window.find('.remove-profile-picture').on('click', function (e) {
+            // Remove picture from profile
+            update_profile(window.user.username, {picture: null});
+            
+            // Update UI immediately
+            $el_window.find('.profile-picture').css('background-image', `url('${window.icons['profile.svg']}')`);
+            $('.profile-image').css('background-image', `url('${window.icons['profile.svg']}')`);
+            $('.profile-image').removeClass('profile-image-has-picture');
+            
+            // Clear from user object
+            if(window.user.profile){
+                window.user.profile.picture = null;
+            }
+            
+            // Hide remove button
+            $el_window.find('.remove-profile-picture').parent().hide();
+        });
     },
 };

--- a/src/gui/src/helpers.js
+++ b/src/gui/src/helpers.js
@@ -2635,7 +2635,9 @@ window.update_profile = function(username, key_vals){
             for (const key in key_vals) {
                 profile[key] = key_vals[key];
                 // update window.user.profile
-                window.user.profile[key] = key_vals[key];
+                if(window.user.profile){
+                    window.user.profile[key] = key_vals[key];
+                }
             }
 
             puter.fs.write('/'+username+'/Public/.profile', JSON.stringify(profile));
@@ -2645,11 +2647,20 @@ window.update_profile = function(username, key_vals){
         });
     }).catch((e)=>{
         if(e?.code === "subject_does_not_exist"){
-            // create .profile file
-            puter.fs.write('/'+username+'/Public/.profile', JSON.stringify({}));
+            // create .profile file with key_vals
+            const profile = {};
+            for (const key in key_vals) {
+                profile[key] = key_vals[key];
+                // update window.user.profile
+                if(window.user.profile){
+                    window.user.profile[key] = key_vals[key];
+                }
+            }
+            puter.fs.write('/'+username+'/Public/.profile', JSON.stringify(profile));
+        } else {
+            // Ignored
+            console.log(e);
         }
-        // Ignored
-        console.log(e);
     });
 }
 

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -238,6 +238,7 @@ const en = {
         refresh: 'Refresh',
         release_address_confirmation: `Are you sure you want to release this address?`,
         remove_from_taskbar:'Remove from Taskbar',
+        remove_profile_picture: 'Remove Profile Picture',
         rename: 'Rename',
         repeat: 'Repeat',
         replace: 'Replace',


### PR DESCRIPTION
## Summary

**WHAT:** Adds a "Remove Profile Picture" button in Account Settings that allows users to remove their profile picture and revert to the default avatar.

**WHY:** Users can currently upload and replace profile pictures, but there was no way to remove a profile picture once set. This feature provides a simple way to clear the profile picture and restore the default state.

**HOW:** 
- Added a conditional "Remove Profile Picture" button below the profile picture in Account Settings
- Button only appears when a profile picture exists
- Clicking the button sets the profile picture to `null` and updates all UI locations immediately
- Also fixed a bug in `update_profile` where it didn't apply `key_vals` when creating a new `.profile` file

**User Impact:** Users can now easily remove their profile picture without needing to replace it with another image.

---

## Before/After Comparison

### Before
- Users could upload and replace profile pictures
- No way to remove a profile picture once set
- Had to upload a new picture to "remove" the old one

### After
- "Remove Profile Picture" button appears below profile picture when one exists
- Clicking the button immediately removes the picture and updates all UI locations
- Button automatically hides after removal
- Removal persists after page refresh

### Screenshots & Demo Video

**Demo Video:** [Watch the full demo on Cap.so](https://cap.so/s/gg585fp4pkmsvzm)

The demo video demonstrates the complete feature flow:
- Uploading a profile picture → button appears immediately
- Clicking "Remove Profile Picture" → picture removed, button disappears
- Page refresh → removal persists (default icon shown, no button)

**Screenshots from the demo:**

**Before (No Profile Picture):**
- Account Settings showing default profile picture placeholder
- No "Remove Profile Picture" button visible (as expected) 
<img width="1714" height="951" alt="NoDeletePFP" src="https://github.com/user-attachments/assets/cb410798-74b2-479c-ad21-a43193c6e190" />


**After (With Profile Picture):**
- Account Settings showing profile picture
- "Remove Profile Picture" button visible below the picture
- Button appears immediately after first upload (bug fix included)
<img width="1714" height="946" alt="deletePFP" src="https://github.com/user-attachments/assets/5b3c5d65-a57a-4ce1-b0da-16b8bc5b2940" />


---

## Testing Instructions

### For Reviewers

**Setup:**
```bash
git checkout <branch-name>
cd src/gui
npm install
npm run build
npm start  # Or use the main npm start from root
```

**Manual Testing Steps:**

1. **Test Button Visibility:**
   - Navigate to: Settings → Account tab
   - **If you have a profile picture:** Verify "Remove Profile Picture" button is visible below the picture
   - **If you don't have a profile picture:** Upload one first (click profile picture), then verify button appears

2. **Test Removal Functionality:**
   - Click "Remove Profile Picture" button
   - **Verify:**
     - [ ] Profile picture in settings window changes to default icon
     - [ ] Toolbar profile icon (top-right) changes to default icon
     - [ ] Remove button disappears
     - [ ] No console errors

3. **Test Persistence:**
   - After removing picture, refresh the page (F5 or Cmd+R)
   - Navigate to: Settings → Account tab
   - **Verify:**
     - [ ] Default icon is still displayed (not the removed picture)
     - [ ] Remove button is NOT visible

4. **Test Re-upload:**
   - After removing picture, click profile picture to upload a new one
   - Select an image file (.png, .jpg, .jpeg)
   - **Verify:**
     - [ ] New picture appears in settings window
     - [ ] New picture appears in toolbar
     - [ ] "Remove Profile Picture" button appears again

5. **Test Edge Cases:**
   - [ ] User with no profile picture: Button should NOT appear
   - [ ] Multiple rapid clicks: Should not cause errors
   - [ ] Console check: No red error messages during any operation

**Quick Console Test:**
```javascript
// Verify translation key
i18n('remove_profile_picture')
// Should return: "Remove Profile Picture"

// Check button state (after opening Settings → Account)
window.checkRemoveButton = function() {
    const $settings = $('.window[data-window-id="settings"]');
    const $button = $settings.find('.remove-profile-picture');
    const hasPicture = !!(window.user?.profile?.picture);
    console.log('Has picture:', hasPicture);
    console.log('Button visible:', $button.is(':visible'));
    console.log('Expected:', hasPicture ? 'VISIBLE' : 'HIDDEN');
};
```

**Automated Tests:**
- N/A - This is a GUI feature that requires manual testing

---

## Additional Information

**Checklist:**
- [x] Has associated issue: #3
- [ ] Required feature flags: N/A
- [x] Changes UI
- [ ] Includes DB Migration: N/A (uses existing filesystem storage)
- [ ] Introduces new feature or API: Yes (new UI feature)
- [ ] Removes existing feature or API: No

**Technical Details:**

**Files Modified:**
1. `src/gui/src/UI/Settings/UITabAccount.js`
   - Added conditional "Remove Profile Picture" button in `html()` function
   - Added click handler in `init()` function
   - Updated `file_opened` handler to dynamically create button if it doesn't exist (fixes button not appearing on first upload)
   - Button now appears immediately after uploading a profile picture for the first time

2. `src/gui/src/i18n/translations/en.js`
   - Added `remove_profile_picture: 'Remove Profile Picture'` translation key

3. `src/gui/src/helpers.js`
   - Fixed `update_profile()` function to handle `null` values correctly
   - Fixed bug where `key_vals` weren't applied when creating new `.profile` file
   - Added safety checks for `window.user.profile`

**Implementation Approach:**
- Follows existing UI patterns (similar to password/username/email change buttons)
- Uses existing `update_profile()` function for data persistence
- Updates all profile picture display locations (settings, toolbar)
- Button visibility is conditional based on `window.user?.profile?.picture`

**Backward Compatibility:**
- Fully backward compatible
- Existing profile pictures unaffected
- No API changes
- No database changes

**Related Files:**
- Research: `memory/github-issues/issue-3/research.md`
- Analysis: `memory/github-issues/issue-3/analysis.md`
- Verification Checklist: `memory/github-issues/issue-3/verification-checklist.md`

