### PR TITLE
feat(desktop): add ability to hide/show all desktop icons (#6)

### DIFF
--- a/src/gui/src/globals.js
+++ b/src/gui/src/globals.js
@@ -99,7 +99,12 @@ if (window.user_preferences === null) {
         show_hidden_files: false,
         language: navigator.language.split("-")[0] || navigator.userLanguage || 'en',
         clock_visible: 'auto',
+        desktop_icons_visible: true,
     }
+}
+// Ensure desktop_icons_visible exists even if preferences already exist
+if (window.user_preferences.desktop_icons_visible === undefined) {
+    window.user_preferences.desktop_icons_visible = true;
 }
 
 window.window_stack = []

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -274,6 +274,8 @@ const en = {
         shortcut_to: "Shortcut to",
         show_all_windows: "Show All Windows",
         show_hidden: 'Show hidden',
+        hide_desktop_icons: 'Hide Desktop Icons',
+        show_desktop_icons: 'Show Desktop Icons',
         sign_in_with_puter: "Sign in with Puter",
         sign_up: "Sign Up",
         signing_in: "Signing in…",

--- a/src/puter-js/src/modules/KV.js
+++ b/src/puter-js/src/modules/KV.js
@@ -10,6 +10,7 @@ const gui_cache_keys = [
     'user_preferences.show_hidden_files',
     'user_preferences.language',
     'user_preferences.clock_visible',
+    'user_preferences.desktop_icons_visible',
     'has_seen_welcome_window',
 ];
 


### PR DESCRIPTION
## Summary

**WHAT & WHY**

This PR adds the ability to toggle visibility of all desktop icons through a right-click context menu option, similar to functionality found in modern desktop operating systems (Windows, macOS, Linux). This allows users to hide icons for a clean desktop appearance while maintaining access to files through other means.

**Changes Made:**
- Added "Hide Desktop Icons" / "Show Desktop Icons" toggle option to desktop context menu
- Implemented preference persistence using KV store (`user_preferences.desktop_icons_visible`)
- Applied visibility state on desktop load to maintain preference across sessions
- Added i18n strings for the new menu options

**Why This Approach:**
- Follows existing pattern: Similar to `show_hidden_files` implementation
- Consistent with codebase: Uses same preference storage mechanism (`puter.kv.set`)
- Maintains backward compatibility: Defaults to showing icons (current behavior)
- Simple CSS-based solution: Uses existing `.item-hidden` class pattern
- Persists across sessions: Uses KV store like other preferences

**User Impact:**
- Users can now hide all desktop icons for a cleaner desktop view
- Preference persists across page reloads and sessions
- Accessible via familiar right-click context menu pattern

## Before/After Comparison

### Before
- Desktop icons were always visible
- No way to hide icons for a clean desktop appearance
- Right-click context menu had no option to toggle icon visibility

### After
- Desktop icons can be hidden/shown via context menu
- Preference persists across sessions
- Context menu includes "Hide Desktop Icons" / "Show Desktop Icons" option
- When icons are hidden, menu shows "Show Desktop Icons" with checkmark
- When icons are visible, menu shows "Hide Desktop Icons" without checkmark

### Video Demonstration

**Video:** https://cap.so/s/h2gsje1x3v8kkpa

The video demonstrates:
- Right-clicking on the desktop to open context menu
- Selecting "Hide Desktop Icons" option
- All desktop icons disappearing
- Right-clicking again to show "Show Desktop Icons" option
- Selecting "Show Desktop Icons" to restore icon visibility

## Testing Instructions

### For Reviewers

**Setup:**
```bash
# Checkout the feature branch
git checkout feature/add-a-way-to-hide-or-show-all-desktop-icons

# Start the development server
npm start

# Open browser to http://localhost:8080 (or configured port)
# Login/authenticate if needed
```

**Manual Testing Steps:**

1. **Test Context Menu Option**
   - Right-click on empty desktop area (not on an icon)
   - Verify "Hide Desktop Icons" option appears in context menu (after "Show/Hide hidden files")
   - Verify no checkmark appears when icons are visible

2. **Test Hide Functionality**
   - Click "Hide Desktop Icons"
   - Verify all desktop icons disappear immediately
   - Verify Trash icon is also hidden
   - Right-click again on desktop
   - Verify menu option now says "Show Desktop Icons" with checkmark (✓)

3. **Test Show Functionality**
   - Click "Show Desktop Icons"
   - Verify all desktop icons reappear immediately
   - Right-click again
   - Verify menu option now says "Hide Desktop Icons" without checkmark

4. **Test Persistence**
   - Hide desktop icons
   - Reload the page (F5 or Cmd+R)
   - Verify icons remain hidden after reload
   - Show desktop icons
   - Reload the page again
   - Verify icons remain visible after reload

5. **Test Edge Cases**
   - Verify files are still accessible via file explorer/search when icons are hidden
   - Test on different screen sizes (if responsive)
   - Check browser console for any errors
   - Verify preference is stored in KV store (check browser DevTools → Application → Local Storage)

**Expected Results:**
- Context menu option appears and functions correctly
- Icons hide/show immediately when toggled
- Preference persists across page reloads
- No console errors
- Files remain accessible through other means when icons are hidden

**Automated Tests:**
No automated tests were added in this PR. Manual testing is sufficient for this UI feature.

## Additional Information

**Checklist:**
- [x] Has associated issue: #6
- [ ] Required feature flags: N/A
- [x] Changes UI
- [ ] Includes DB Migration: N/A
- [ ] Introduces new feature or API: Yes (new user preference)
- [ ] Removes existing feature or API: No

**Technical Details:**

**Implementation Details:**
- Uses existing `.item-hidden` CSS class (no new CSS needed)
- Preference stored in KV store as `user_preferences.desktop_icons_visible`
- Default value is `true` (show icons) for backward compatibility
- Context menu item positioned after "Show/Hide hidden files" option
- Visibility applied on desktop load to maintain state across sessions
- Selector `.desktop.item-container > .item` targets all desktop items including Trash

**Backward Compatibility:**
- Existing users default to showing icons (current behavior)
- New preference key: `user_preferences.desktop_icons_visible`
- If preference doesn't exist, defaults to `true` (show icons)

**Dependencies:**
- No new npm packages needed
- No new environment variables
- Uses existing `puter.kv` API
- Uses existing `.item-hidden` CSS class

